### PR TITLE
Remove Sorting Files in company_data.py

### DIFF
--- a/src/data/company_data.py
+++ b/src/data/company_data.py
@@ -131,7 +131,6 @@ for r, _, f in os.walk(API_COMPANY_DATA_PATH):
 if TARGET_COMPANIES:
   files = [file + '.json' for file in TARGET_COMPANIES]
 
-files = sorted(files)
 
 for file in tqdm.tqdm(files):
     with open(root+"/"+file,'r') as f:


### PR DESCRIPTION
Remove Sorting Files in company_data.py .
This was done to enforce reproducibility. But we get a weird error for some reason if we do this. hence reverting